### PR TITLE
add test for kct_xxx:bicycle and network versus ref

### DIFF
--- a/map/php/func.php
+++ b/map/php/func.php
@@ -289,6 +289,21 @@ function checkTagOsmcKctColor($osmc, $kctColor){
     return $osmcColor==$kctColor ? 0 : 1;
 }
 
+/**
+ * @param $network
+ * @param $ref
+ * @return int
+ */
+function checkTagCycleNet($network, $ref){
+    //echo "$network:$ref<br/>\n";
+
+    if($network == "lcn" && !is_numeric($ref)) return 0;
+    if($network == "lcn" && is_numeric($ref) && $ref > 999) return 0;
+    if($network == "rcn" && is_numeric($ref) && $ref > 999) return 0;
+    if($network == "ncn" && is_numeric($ref) && $ref > 0 && $ref < 1000) return 0;
+
+    return 1;
+}
 
 /**
  * @param $osmc

--- a/tables/stats.php
+++ b/tables/stats.php
@@ -26,6 +26,7 @@ $statistics = getCount(); ?>
     <tr><td>hodnota network nekoresponduje s hodnotou kct_*: <td><a href="index.php?pg=table&area=all&specific=err_network"><?php echo $error_stats['err_network']; ?></a><td><?php echo $error_perc['err_network'];?>
     <tr><td>typ cesty v rozporu s ostatnimi u tagu osmc:symbol, kct_* nebo route: <td><a href="index.php?pg=table&area=all&specific=err_type"><?php echo $error_stats['err_type']; ?></a><td><?php echo $error_perc['err_type'];?>
     <tr><td>barva cesty v rozporu u osmc:symbol a kct_*: <td><a href="index.php?pg=table&area=all&specific=err_color"><?php echo $error_stats['err_color']; ?></a><td><?php echo $error_perc['err_color'];?>
+    <tr><td>hodnota network u cyklotrasy nekoresponduje s cislem v ref: <td><a href="index.php?pg=table&area=all&specific=err_cyclenet"><?php echo $error_stats['err_cyclenet']; ?></a><td><?php echo $error_perc['err_cyclenet'];?>
 </table>
 </div>
 

--- a/tables/table.php
+++ b/tables/table.php
@@ -19,7 +19,7 @@ if($specific=='all_missing'){
     $spec_query = "and not exist(relations.tags,'osmc:symbol')";
 } else {
     $filter = $specific;
-} 
+}
 if(!(isset($spec_query))){
     $spec_query = "";
 }
@@ -27,6 +27,7 @@ if(!(isset($filter))){
     $filter = "";
 }
 $query = "SELECT id, hstore_to_json(tags) AS tags FROM relations WHERE ".NOT_CYCLO." ".$spec_query." ORDER BY id";
+//echo "q: $query\n";
 $result = pg_query($db, $query);
 
 ?>
@@ -49,16 +50,16 @@ $result = pg_query($db, $query);
                 $red = getWrong($incorrect, $kctKey);
 
                     /* filtrovani */
-                if( ($filter=='w_network' && !in_array('network', $red)) 
-                || ($filter=='w_complete' && !in_array('complete', $red)) 
-                || ($filter=='w_osmc:symbol' && !in_array('osmc:symbol', $red)) 
-                || ($filter=='route' && !in_array('route', $red)) 
+                if( ($filter=='w_network' && !in_array('network', $red))
+                || ($filter=='w_complete' && !in_array('complete', $red))
+                || ($filter=='w_osmc:symbol' && !in_array('osmc:symbol', $red))
+                || ($filter=='route' && !in_array('route', $red))
                 || ($filter=='kct' && !in_array($kctKey, $red))){
                     continue;
                  }
-                    
+
                  /* vyhledavani chyb */
-                
+
                 $orange = getMissing($tags, $kctKey);
 
                 $checked = getCheckedValues($kctKey);
@@ -83,7 +84,7 @@ $result = pg_query($db, $query);
 				$red[] = 'route';
 			    } else { continue; }
 			} else { continue; }
-                }                
+                }
                 if($filter=='err_color'){
 			if(array_key_exists('route', $tags) && array_key_exists('osmc:symbol', $tags) && array_key_exists($kctKey, $tags)
 			    && !(in_array('osmc:symbol', $red)) && !(in_array($kctKey, $red))){
@@ -92,6 +93,16 @@ $result = pg_query($db, $query);
 				$errorStr .= "barva cesty v rozporu u osmc:symbol/kct; ";
 				$red[] = 'osmc:symbol';
 				$red[] = $kctKey;
+			    } else { continue; }
+			} else { continue; }
+                }
+                if($filter=='err_cyclenet'){
+			if(array_key_exists('network', $tags) && array_key_exists($kctKey, $tags)
+			    && !(in_array('network', $red)) && !(in_array($kctKey, $red)) && $tags[$kctKey] == 'bicycle'){
+			    if(!array_key_exists('ref', $tags) || checkTagCycleNet($tags['network'], $tags['ref'])>0){
+				$errorStr .= "network type nekoresponduje s ref u cyklostezky; ";
+				$red[] = 'network';
+				$red[] = 'ref';
 			    } else { continue; }
 			} else { continue; }
                 }
@@ -114,9 +125,9 @@ $result = pg_query($db, $query);
                     } else {
                         echo "<td>".$tags[$key]."</td>";
                     }
-                }        
+                }
             ?>
-            
+
         </tr>
         <?php } ?>
     </table>


### PR DESCRIPTION
network=ncn -> ref is numeric and in (0,999)
network=rcn -> ref is numeric and > 999
network=lcn -> ref is either numeric and > 999 or non-numeric

applies only on kct_XXX=bicycle routes, not route=bycicle for now!
